### PR TITLE
Require fsspec 0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About gcsfs
 
 Home: https://github.com/dask/gcsfs
 
-Package license: BSD
+Package license: BSD-3-Clause
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/gcsfs-feedstock/blob/master/LICENSE.txt)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   noarch: python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - google-auth
     - google-auth-oauthlib
     - requests
-    - fsspec >=0.8.0
+    - fsspec >=0.9.0,<0.10.0
     - aiohttp
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,8 +35,7 @@ test:
 
 about:
   home: https://github.com/dask/gcsfs
-  license: BSD
-  license_family: BSD
+  license: BSD-3-Clause
   license_file: LICENSE.txt
   summary: Pythonic file-system interface for Google Cloud Storage
   doc_url: http://gcsfs.readthedocs.io/en/latest/


### PR DESCRIPTION
Updates the `fsspec` requirement for `gcsfs` to use `0.9.0`

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

xref: https://github.com/intake/filesystem_spec/issues/598